### PR TITLE
Add support for error status 10 (shutdown).

### DIFF
--- a/src/apns_connection.erl
+++ b/src/apns_connection.erl
@@ -318,4 +318,5 @@ parse_status(5) -> missing_token_size;
 parse_status(6) -> missing_topic_size;
 parse_status(7) -> missing_payload_size;
 parse_status(8) -> invalid_token;
+parse_status(10) -> shutdown;
 parse_status(_) -> unknown.


### PR DESCRIPTION
This error status code was added at some point (the [revision history](https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/RevisionHistory.html#//apple_ref/doc/uid/TP40008194-CH99-SW1) does not mention a date for some reason).
