### PR TITLE
Export apns:default_connection/0 to allow key file password to be added,...

### DIFF
--- a/src/apns.erl
+++ b/src/apns.erl
@@ -20,6 +20,7 @@
 -export([send_content_available/2, send_content_available/3]).
 -export([estimate_available_bytes/1]).
 -export([message_id/0, expiry/1, timestamp/1]).
+-export([default_connection/0]).
 
 -type status() :: no_errors | processing_error | missing_token | missing_topic | missing_payload |
                   missing_token_size | missing_topic_size | missing_payload_size | invalid_token |


### PR DESCRIPTION
... e.g.

%% Pull password from e.g. sys.config here
ConnectionProfile = (apns:default_connection())#apns_connection{cert_password=Password, error_fun=fun ?MODULE:handle_apns_error/2, feedback_fun=fun ?MODULE:handle_apns_feedback/2},
Connection = apns:connect(apns_connection, ConnectionProfile)

It's this approach vs. modifying default_connection/0 directly.  This is the least intrusive.
