### PR TITLE
Remove env-section from apns.app.src

### DIFF
--- a/priv/app.config
+++ b/priv/app.config
@@ -1,0 +1,12 @@
+% vim: ft=erlang:
+[     {apns, [ {apple_host,       "gateway.sandbox.push.apple.com"}
+             , {apple_port,       2195}
+             , {cert_file,        "priv/cert.pem"}
+             , {key_file,         undefined}
+             , {timeout,          30000}
+             , {feedback_host,    "feedback.sandbox.push.apple.com"}
+             , {feedback_port,    2196}
+             , {feedback_timeout, 600000} %% 10 Minutes
+             ]
+      }
+].

--- a/src/apns.app.src
+++ b/src/apns.app.src
@@ -9,13 +9,5 @@
                   ssl
                  ]},
   {mod, {apns_app, []}},
-  {env, [{apple_host,       "gateway.sandbox.push.apple.com"},
-         {apple_port,       2195},
-         {cert_file,        "priv/cert.pem"},
-         {key_file,         undefined},
-         {timeout,          30000},
-         {feedback_host,    "feedback.sandbox.push.apple.com"},
-         {feedback_port,    2196},
-         {feedback_timeout, 600000} %% 10 Minutes
-        ]}
+  {env, []}
  ]}.


### PR DESCRIPTION
The env-section effectively overrides any value set using
application:set_env/3 before apns is loaded making it harder to test,
etc. The data in env doesn't really add anyhing since the user most
definitely want to update that with it's own info
