### PR TITLE
Rename queue type to queue:queue()

### DIFF
--- a/src/apns_queue.erl
+++ b/src/apns_queue.erl
@@ -29,7 +29,7 @@
     code_change/3]).
 
 -record(state, {
-    queue = queue:new() :: queue(),
+    queue = queue:new() :: queue:queue(),
     max_entries = ?DEFAULT_MAX_ENTRIES :: pos_integer()
 }).
 
@@ -108,7 +108,7 @@ code_change(_OldVsn, State, _Extra) ->
 %% Server implementation, a.k.a.: callbacks
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--spec recover_fail(ID::binary(), Queue::queue()) -> {apns:msg(), [apns:msg()]}.
+-spec recover_fail(ID::binary(), Queue::queue:queue()) -> {apns:msg(), [apns:msg()]}.
 %@hidden
 recover_fail(ID, Queue) ->
     Now = apns:expiry(0),


### PR DESCRIPTION
Fixes compilation on 17.0+ because the project has warnings as error and that type is deprecated.