### PR TITLE
update elvis version 0.2.3 to 0.2.4

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -19,7 +19,7 @@
         {sync, ".*",   {git, "https://github.com/inaka/sync.git", "0.1"}},
         {katana, ".*", {git, "https://github.com/inaka/erlang-katana.git", "0.2.0"}},
         {eper, ".*",   {git, "https://github.com/massemanet/eper.git", "0.90.0"}},
-        {elvis, ".*",  {git, "https://github.com/inaka/elvis.git", "0.2.3"}}
+        {elvis, ".*",  {git, "https://github.com/inaka/elvis.git", "0.2.4"}}
         ]}.
 {dialyzer_opts, [{warnings, [unmatched_returns, error_handling, race_conditions, behaviours]}]}.
 {edoc_opts, [{report_missing_types, true}, {source_path, ["src"]}, {report_missing_types, true}, {todo, true}, {packages, false}, {subpackages, false}]}.


### PR DESCRIPTION
Problem:
- elvis 0.2.3 using git@ for the deps which clause permission problem in server.

Solution:
- evlis 0.2.4 already change to use git:// instead 