### PR TITLE
Added support for 'category' field

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -82,6 +82,7 @@ Actually, send\_message/3, send\_message/4, send\_message/5, send\_message/6, se
       alert  = "alert" ,
       badge  = 1,
       sound  = "sound" ,
+      category = "EMAIL_ACTION",
       expiry = 1348000749,
       device_token = "this_is_a_valid_device_token"
     }).

--- a/include/apns.hrl
+++ b/include/apns.hrl
@@ -24,6 +24,7 @@
                    content_available = false    :: boolean(),
                    alert = none                 :: none | apns:alert(),
                    badge = none                 :: none | integer(),
+                   category = none              :: none | string(),
                    sound = none                 :: none | apns:apns_str(),
                    apns_extra = []              :: none | [{atom(), integer()|boolean()|string()}],
                    extra = []                   :: proplists:proplist(),

--- a/src/apns_connection.erl
+++ b/src/apns_connection.erl
@@ -53,12 +53,14 @@ build_payload(Msg) ->
   #apns_msg{ alert = Alert
            , badge = Badge
            , sound = Sound
+           , category = Category
            , apns_extra=Apns_Extra
            , content_available = Content_Available
            , extra = Extra} = Msg,
   build_payload(
     [ {alert, Alert}
     , {badge, Badge}
+    , {category, Category}
     , {sound, Sound}] ++ Apns_Extra, Extra, Content_Available).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
IOS 8 supports interactive notifications. In order to use it we need to add the field 'category' in the payload.