### PR TITLE
Reset connection on inactivity period

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,6 +27,7 @@ Using apns4erl is quite simple. First, setup something similar to this in your s
       {key_file, undefined},
       {cert_password, undefined},
       {timeout, 30000},
+      {expires_conn, 300}
       {feedback_port, 2196},
       {feedback_host, "feedback.sandbox.push.apple.com"},
       {feedback_timeout, 18000000}

--- a/include/apns.hrl
+++ b/include/apns.hrl
@@ -16,7 +16,8 @@
                           feedback_host     = "feedback.sandbox.push.apple.com"     :: string(),
                           feedback_port     = 2196                                  :: integer(),
                           feedback_fun      = fun erlang:display/1                  :: fun(({calendar:datetime(), string()}) -> _),
-                          feedback_timeout  = 30*60*1000                            :: pos_integer()
+                          feedback_timeout  = 30*60*1000                            :: pos_integer(),
+                          expires_conn      = 300                                   :: pos_integer()
                           }).
 -record(apns_msg, {id = apns:message_id()       :: binary(),
                    expiry = apns:expiry(86400)  :: non_neg_integer(), %% default = 1 day

--- a/src/apns.erl
+++ b/src/apns.erl
@@ -284,4 +284,6 @@ default_connection() ->
         get_env(feedback_host, DefaultConn#apns_connection.feedback_host)
     , feedback_port =
         get_env(feedback_port, DefaultConn#apns_connection.feedback_port)
+    , expires_conn =
+        get_env(expires_conn,  DefaultConn#apns_connection.expires_conn)
     }.


### PR DESCRIPTION
Original code by @manuel-rubio 

Due some bad configured firewalls some connections are closed after some idle time. With this patch if a connection was idle more than a configured time it was closed an reopened to avoid timeouts.

