### PR TITLE
Use tag atom for deps

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,11 +15,11 @@
             warn_missing_spec,
             warn_untyped_record, debug_info]}.
 {deps_dir, "deps"}.
-{deps, [{jiffy, ".*",  {git, "https://github.com/davisp/jiffy.git", "0.13.3"}},
-        {sync, ".*",   {git, "https://github.com/inaka/sync.git", "0.1"}},
-        {katana, ".*", {git, "https://github.com/inaka/erlang-katana.git", "0.2.0"}},
-        {eper, ".*",   {git, "https://github.com/massemanet/eper.git", "0.90.0"}},
-        {elvis, ".*",  {git, "https://github.com/inaka/elvis.git", "0.2.4"}}
+{deps, [{jiffy, ".*",  {git, "https://github.com/davisp/jiffy.git", {tag, "0.13.3"}}},
+        {sync, ".*",   {git, "https://github.com/inaka/sync.git", {tag, "0.1"}}},
+        {katana, ".*", {git, "https://github.com/inaka/erlang-katana.git", {tag, "0.2.0"}}},
+        {eper, ".*",   {git, "https://github.com/massemanet/eper.git", {tag, "0.90.0"}}},
+        {elvis, ".*",  {git, "https://github.com/inaka/elvis.git", {tag, "0.2.4"}}}
         ]}.
 {dialyzer_opts, [{warnings, [unmatched_returns, error_handling, race_conditions, behaviours]}]}.
 {edoc_opts, [{report_missing_types, true}, {source_path, ["src"]}, {report_missing_types, true}, {todo, true}, {packages, false}, {subpackages, false}]}.


### PR DESCRIPTION
rebar3 throws warnings without a qualifier for the version ref. This should be backwards compatible with older rebars too.