### PR TITLE
Only support tls version 1.1

### DIFF
--- a/src/apns_connection.erl
+++ b/src/apns_connection.erl
@@ -113,7 +113,7 @@ ssl_opts(Connection) ->
       undefined -> [];
       Password -> [{password, Password}]
     end,
-  [{mode, binary} | Opts].
+  [{mode, binary}, {versions, ['tlsv1.1']} | Opts].
 
 %% @hidden
 open_out(Connection) ->


### PR DESCRIPTION
Erlang/OTP can only handle certain hashing functions and apple has
changed there. The current fix is to only support tlsv1.1.

http://erlang.org/pipermail/erlang-questions/2015-June/084935.html

This fixed it locally. Unable to execute the test though :-/