### PR TITLE
Compile error using Erlang R16B02 (erts-5.10.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.rebar/
 deps
 ebin
 log/*.log

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,9 @@ PROJECT=apns
 
 CONFIG?=priv/app.config
 
-DEPS = jiffy sync katana eper
-dep_jiffy = git https://github.com/davisp/jiffy 0.13.3
+DEPS = jiffy sync
+dep_jiffy = git https://github.com/davisp/jiffy 0.14.3
 dep_sync = git https://github.com/inaka/sync.git 0.1
-dep_katana =  git https://github.com/inaka/erlang-katana 0.2.0
-dep_eper = git https://github.com/massemanet/eper.git 0.90.0
 
 TEST_DEPS = mock_apns
 dep_mock_apns = git https://github.com/tomekowal/mockapn.git 4b4c1fd21706060eba2142cc405ce7c8b3396513

--- a/elvis.config
+++ b/elvis.config
@@ -3,7 +3,7 @@
    elvis,
    [
     {config,
-     [#{dirs => ["src"],
+     [#{dirs => ["src", "test"],
         filter => "*.erl",
         rules => [{elvis_style, line_length, #{limit => 80}},
                   {elvis_style, no_tabs},

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "R1[456]|17"}.
+{require_otp_vsn, "R1[456]|17|18"}.
 {erl_opts, [{src_dirs, ["src", "test"]},
             warn_unused_vars,
             warn_export_all,
@@ -16,10 +16,7 @@
             warn_untyped_record, debug_info]}.
 {deps_dir, "deps"}.
 {deps, [{jiffy, ".*",  {git, "https://github.com/davisp/jiffy.git", {tag, "0.13.3"}}},
-        {sync, ".*",   {git, "https://github.com/inaka/sync.git", {tag, "0.1"}}},
-        {katana, ".*", {git, "https://github.com/inaka/erlang-katana.git", {tag, "0.2.0"}}},
-        {eper, ".*",   {git, "https://github.com/massemanet/eper.git", {tag, "0.90.0"}}},
-        {elvis, ".*",  {git, "https://github.com/inaka/elvis.git", {tag, "0.2.4"}}}
+        {sync, ".*",   {git, "https://github.com/inaka/sync.git", {tag, "0.1"}}}
         ]}.
 {dialyzer_opts, [{warnings, [unmatched_returns, error_handling, race_conditions, behaviours]}]}.
 {edoc_opts, [{report_missing_types, true}, {source_path, ["src"]}, {report_missing_types, true}, {todo, true}, {packages, false}, {subpackages, false}]}.


### PR DESCRIPTION
Hi friend,

I'm new on apns4erl, I cloned the code then I try to make it. everything fine till these logs:
==> sync (compile)
make[2]: Leaving directory `/home/jiangyang/apns4erl/deps/sync'
make[2]: Entering directory `/home/jiangyang/apns4erl/deps/aleppo'
mkdir -p ebin
erl -make 
cp src/aleppo.app.src ebin/aleppo.app
make[2]: Leaving directory `/home/jiangyang/apns4erl/deps/aleppo'
 ERLC   ktn_json.erl ktn_debug.erl ktn_rpc.erl ktn_type.erl ktn_numbers.erl ktn_maps.erl ktn_task.erl ktn_date.erl ktn_recipe_verify.erl ktn_code.erl ktn_recipe.erl ktn_random.erl
src/ktn_recipe.erl:185: syntax error before: '{'
src/ktn_recipe.erl:9: function verify/1 undefined
make[1]: *** [ebin/katana.app] Error 1
make[1]: Leaving directory `/home/jiangyang/apns4erl/deps/katana'
make[1]: Entering directory `/home/jiangyang/apns4erl/deps/eper'
==> eper (compile)
==> eper (escriptize)
make[1]: Leaving directory `/home/jiangyang/apns4erl/deps/eper'
 ERLC   apns_queue.erl apns_sup.erl apns_connection.erl apns.erl
src/apns_queue.erl:32: referring to built-in type queue as a remote type; please take out the module name
src/apns_queue.erl:111: referring to built-in type queue as a remote type; please take out the module name