### PR TITLE
apns_queue.erl has problem

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "R1[456]|17|18"}.
+{require_otp_vsn, "17|18"}.
 {erl_opts, [{src_dirs, ["src", "test"]},
             warn_unused_vars,
             warn_export_all,


### PR DESCRIPTION
line 32, line 111, Queue:queue() compile error:
must take out module name!


make[1]: Leaving directory `/home/jiangyang/apns4erl/deps/sync'
 ERLC   apns_queue.erl apns_sup.erl apns_connection.erl apns.erl
src/apns_queue.erl:32: referring to built-in type queue as a remote type; please take out the module name
src/apns_queue.erl:111: referring to built-in type queue as a remote type; please take out the module name