### PR TITLE
device_token accept binary and list；fix some elvis errors

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -3,42 +3,41 @@
    elvis,
    [
     {config,
-     [#{dirs => ["src", "test"],
+     [#{dirs => ["src"],
         filter => "*.erl",
-        rules => [{elvis_style, line_length, #{limit => 80}},
-                  {elvis_style, no_tabs},
-                  {elvis_style, macro_names},
-                  {elvis_style, macro_module_names},
-                  {elvis_style, operator_spaces, #{rules => [{right, ","},
-                                                             {right, "++"},
-                                                             {left, "++"}]}},
-                  {elvis_style, nesting_level, #{level => 3}},
-                  {elvis_style, god_modules, #{limit => 25}},
-                  {elvis_style, no_if_expression},
-                  {elvis_style, invalid_dynamic_call, #{ignore => [elvis]}},
-                  {elvis_style, used_ignored_variable},
-                  {elvis_style, no_behavior_info},
+        rules => [{elvis_style, line_length, [80]},
+                  {elvis_style, no_tabs, []},
+                  {elvis_style, macro_names, []},
+                  {elvis_style, macro_module_names, []},
+                  {elvis_style, operator_spaces, [{right, ","},
+                                                  {right, "++"},
+                                                  {left, "++"}]},
+                  {elvis_style, nesting_level, [3]},
+                  {elvis_style, god_modules, [25]},
+                  {elvis_style, no_if_expression, []},
+                  {elvis_style, invalid_dynamic_call, [elvis]},
+                  {elvis_style, used_ignored_variable, []},
+                  {elvis_style, no_behavior_info, []},
                   {
                     elvis_style,
                     module_naming_convention,
-                    #{regex => "^([a-z][a-z0-9]*_?)*(_SUITE)?$",
-                      ignore => []}
+                    ["^([a-z][a-z0-9]*_?)*(_SUITE)?$", []]
                   },
-                  {elvis_style, state_record_and_type},
-                  {elvis_style, no_spec_with_records}
+                  {elvis_style, state_record_and_type, []},
+                  {elvis_style, no_spec_with_records, []}
                  ]
        },
       #{dirs => ["."],
         filter => "Makefile",
-        rules => [{elvis_project, no_deps_master_erlang_mk, #{ignore => [sync]}}]
+        rules => [{elvis_project, no_deps_master_erlang_mk, []}]
        },
       #{dirs => ["."],
         filter => "rebar.config",
-        rules => [{elvis_project, no_deps_master_rebar, #{ignore => []}}]
+        rules => [{elvis_project, no_deps_master_rebar, []}]
        },
       #{dirs => ["."],
         filter => "elvis.config",
-        rules => [{elvis_project, old_configuration_format}]
+        rules => [{elvis_project, old_configuration_format, []}]
        }
      ]
     }

--- a/elvis.config
+++ b/elvis.config
@@ -3,41 +3,42 @@
    elvis,
    [
     {config,
-     [#{dirs => ["src"],
+     [#{dirs => ["src", "test"],
         filter => "*.erl",
-        rules => [{elvis_style, line_length, [80]},
-                  {elvis_style, no_tabs, []},
-                  {elvis_style, macro_names, []},
-                  {elvis_style, macro_module_names, []},
-                  {elvis_style, operator_spaces, [{right, ","},
-                                                  {right, "++"},
-                                                  {left, "++"}]},
-                  {elvis_style, nesting_level, [3]},
-                  {elvis_style, god_modules, [25]},
-                  {elvis_style, no_if_expression, []},
-                  {elvis_style, invalid_dynamic_call, [elvis]},
-                  {elvis_style, used_ignored_variable, []},
-                  {elvis_style, no_behavior_info, []},
+        rules => [{elvis_style, line_length, #{limit => 80}},
+                  {elvis_style, no_tabs},
+                  {elvis_style, macro_names},
+                  {elvis_style, macro_module_names},
+                  {elvis_style, operator_spaces, #{rules => [{right, ","},
+                                                             {right, "++"},
+                                                             {left, "++"}]}},
+                  {elvis_style, nesting_level, #{level => 3}},
+                  {elvis_style, god_modules, #{limit => 25}},
+                  {elvis_style, no_if_expression},
+                  {elvis_style, invalid_dynamic_call, #{ignore => [elvis]}},
+                  {elvis_style, used_ignored_variable},
+                  {elvis_style, no_behavior_info},
                   {
                     elvis_style,
                     module_naming_convention,
-                    ["^([a-z][a-z0-9]*_?)*(_SUITE)?$", []]
+                    #{regex => "^([a-z][a-z0-9]*_?)*(_SUITE)?$",
+                      ignore => []}
                   },
-                  {elvis_style, state_record_and_type, []},
-                  {elvis_style, no_spec_with_records, []}
+                  {elvis_style, state_record_and_type},
+                  {elvis_style, no_spec_with_records}
                  ]
        },
       #{dirs => ["."],
         filter => "Makefile",
-        rules => [{elvis_project, no_deps_master_erlang_mk, []}]
+        rules => [{elvis_project, no_deps_master_erlang_mk, #{ignore => [sync]}}]
        },
       #{dirs => ["."],
         filter => "rebar.config",
-        rules => [{elvis_project, no_deps_master_rebar, []}]
+        rules => [{elvis_project, no_deps_master_rebar, #{ignore => []}}]
        },
       #{dirs => ["."],
         filter => "elvis.config",
-        rules => [{elvis_project, old_configuration_format, []}]
+        rules => [{elvis_project, old_configuration_format}]
        }
      ]
     }

--- a/src/apns_connection.erl
+++ b/src/apns_connection.erl
@@ -172,7 +172,7 @@ handle_cast(Msg, State=#state{ out_socket = undefined
                              , name = Name
                              }) ->
   try
-    InfoLoggerFun("[ ~p ] Reconnecting to APNS...",[Name]),
+    InfoLoggerFun("[ ~p ] Reconnecting to APNS...", [Name]),
     Timeout = epoch() + Connection#apns_connection.expires_conn,
     case open_out(Connection) of
       {ok, Socket} -> handle_cast(Msg,
@@ -189,7 +189,7 @@ handle_cast(Msg, State) when is_record(Msg, apns_msg) ->
   case State#state.out_expires =< epoch() of
     true ->
       ssl:close(Socket),
-      handle_cast(Msg,State#state{out_socket = undefined});
+      handle_cast(Msg, State#state{out_socket = undefined});
     false ->
       Connection = State#state.connection,
       Timeout = epoch() + Connection#apns_connection.expires_conn,
@@ -296,7 +296,7 @@ handle_info(reconnect, State = #state{connection = Connection
                                      , info_logger_fun = InfoLoggerFun
                                      , name = Name
                                      }) ->
-  InfoLoggerFun("[ ~p ] Reconnecting the Feedback server...",[Name]),
+  InfoLoggerFun("[ ~p ] Reconnecting the Feedback server...", [Name]),
   case open_feedback(Connection) of
     {ok, InSocket} -> {noreply, State#state{in_socket = InSocket}};
     {error, Reason} -> {stop, {in_closed, Reason}, State}
@@ -437,11 +437,11 @@ build_frame(MsgId, Expiry, BinToken, Payload, Priority) ->
     5:8, 1:16/big, Priority:8>>.
 
 epoch() ->
-  {M,S,_} = os:timestamp(),
+  {M, S, _} = os:timestamp(),
   M * 1000000 + S.
 
 call(Fun, Args) when is_function(Fun), is_list(Args) ->
     apply(Fun, Args);
-call({M,F}, Args) when is_list(Args) ->
-    apply(M,F,Args).
+call({M, F}, Args) when is_list(Args) ->
+    apply(M, F, Args).
 

--- a/src/apns_queue.erl
+++ b/src/apns_queue.erl
@@ -35,9 +35,9 @@
 
 -type state() :: #state{}.
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Public API
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %% @doc  Stops the connection
 -spec stop(QID :: pid()) -> ok.
@@ -57,9 +57,9 @@ fail(QID, ID) ->
 start_link() ->
   gen_server:start_link(?MODULE, [], []).
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Server implementation, a.k.a.: callbacks
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %% @hidden
 -spec init([]) -> {ok, state()}.
@@ -67,11 +67,12 @@ init([]) ->
     {ok, #state{}}.
 
 %% @hidden
--spec handle_cast(stop | term(), state()) -> {noreply, state()} | {stop, normal | {error, term()}, state()}.
+-spec handle_cast(stop | term(), state()) ->
+    {noreply, state()} | {stop, normal | {error, term()}, state()}.
 handle_cast(stop, State) ->
     {stop, normal, State};
 
-handle_cast({in, Msg}, #state{max_entries=MaxEntries,queue=OldQueue}=State) ->
+handle_cast({in, Msg}, #state{max_entries=MaxEntries, queue=OldQueue}=State) ->
     Queue = case MaxEntries =< queue:len(OldQueue) of
         true -> queue:liat(OldQueue);
         false -> OldQueue
@@ -82,7 +83,8 @@ handle_cast(_Msg, State) ->
     {noreply, State}.
 
 %% @hidden
--spec handle_call(X::term(), reference(), state()) -> {reply, {Failed::apns:msg(), RestToRetry::[apns:msg()]}, state()}.
+-spec handle_call(X::term(), reference(), state()) ->
+    {reply, {Failed::apns:msg(), RestToRetry::[apns:msg()]}, state()}.
 handle_call({fail, ID}, _From, #state{queue=Queue}=State) ->
     {reply, recover_fail(ID, Queue), State#state{queue=queue:new()}};
 
@@ -104,11 +106,12 @@ terminate(_Reason, _State) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Server implementation, a.k.a.: callbacks
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--spec recover_fail(ID::binary(), Queue::queue:queue()) -> {apns:msg(), [apns:msg()]}.
+-spec recover_fail(ID::binary(), Queue::queue:queue()) ->
+    {apns:msg(), [apns:msg()]}.
 %@hidden
 recover_fail(ID, Queue) ->
     Now = apns:expiry(0),


### PR DESCRIPTION
1. Device_token accept binary 
   Sometimes we store device_token in binary, we don't want to transform binary to list every time
  
   Another reason is binary is faster than list, see benchmark test on 
   https://gist.github.com/zhongwencool/659442f5e51a22c97ae1
```erlang
  1> hex:test().
  true
  BinTime:1927792 StrTime:2175268 Diff:-247476
  ok
```
       Maybe  hexstr_to_bin/1 could accept binary will be better?

2. fix some elvis errors 

3. update elvis.config

