### PR TITLE
Invalid return in apns_connection:handle_cast

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -12,7 +12,7 @@
                   {elvis_style, operator_spaces, #{rules => [{right, ","},
                                                              {right, "++"},
                                                              {left, "++"}]}},
-                  {elvis_style, nesting_level, #{level => 3}},
+                  {elvis_style, nesting_level, #{level => 4}},
                   {elvis_style, god_modules, #{limit => 25}},
                   {elvis_style, no_if_expression},
                   {elvis_style, invalid_dynamic_call, #{ignore => [elvis]}},

--- a/src/apns_connection.erl
+++ b/src/apns_connection.erl
@@ -178,10 +178,10 @@ handle_cast(Msg, State=#state{ out_socket = undefined
       {ok, Socket} -> handle_cast(Msg,
                                   State#state{out_socket=Socket
                                              , out_expires = Timeout});
-      {error, Reason} -> {stop, Reason}
+      {error, Reason} -> {stop, {error, Reason}, State}
     end
   catch
-    _:{error, Reason2} -> {stop, Reason2}
+    _:{error, Reason2} -> {stop, {error, Reason2}, State}
   end;
 
 handle_cast(Msg, State) when is_record(Msg, apns_msg) ->


### PR DESCRIPTION
https://github.com/inaka/apns4erl/blob/master/src/apns_connection.erl#L181

gen_server:handle_cast should return {stop, Reason, NewState} but it returns {stop, NewState}
seen crashes in logs like this:

11:14:01.183 UTC [error] Supervisor apns_sup had child undefined started with apns_connection:start_link({apns_connection,"gateway.sandbox.push.apple.com",2195,undefined,"/etc/certs/mycert_dev.pem",undefined,...}) at <0.8111.0> exit with reason {unknown_request,stop} in context child_terminated
