### PR TITLE
export apns:connect/1

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ ok
 After filling the `config` file and running `apns4erl` app we can start creating connections. As we mentioned before there are two types of connections. Both are created using the function `apns:connect/2` where the first argument is the type and the second one is the connection's name.
 
 ```erlang
-2> apns:connect(cert, my_first_connection).
+1> apns:connect(cert, my_first_connection).
 {ok,<0.87.0>}
+2> apns:connect(#{name => aother_cert, apple_host => "api.push.apple.com", apple_host => 443,
+certtile => "cert.pem", keyfile => "priv/key.pem", type => cert}).
 3> apns:connect(token, my_second_connection).
 {ok,<0.95.0>}
 ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ After filling the `config` file and running `apns4erl` app we can start creating
 1> apns:connect(cert, my_first_connection).
 {ok,<0.87.0>}
 2> apns:connect(#{name => aother_cert, apple_host => "api.push.apple.com", apple_host => 443,
-certtile => "cert.pem", keyfile => "priv/key.pem", type => cert}).
+certtile => "priv/cert.pem", keyfile => "priv/key.pem", type => cert}).
 3> apns:connect(token, my_second_connection).
 {ok,<0.95.0>}
 ```

--- a/src/apns.app.src
+++ b/src/apns.app.src
@@ -6,6 +6,7 @@
   {applications, [
     kernel,
     stdlib,
+    jsx,
     gun,
     base64url
   ]},

--- a/src/apns.erl
+++ b/src/apns.erl
@@ -22,6 +22,7 @@
 %% API
 -export([ start/0
         , stop/0
+        , connect/1
         , connect/2
         , close_connection/1
         , push_notification/3


### PR DESCRIPTION
1. export ```apns:connect/1```, so i can handle two production apps(open two connections) in one Erlang application.

1. add ```jsx``` to ```apns.app.src```, i don't need to add ```jsx``` to my app's(top level app) xxx.app.src

1. Readme add ```apns:connect/1```