### PR TITLE
use os:cmd/1, more robust

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -25,7 +25,7 @@
 {deps, [
   {gun, {git, "https://github.com/ninenines/gun.git", {branch, "master"}}},
   {jsx, "2.8.1"},
-  {katana, "0.4.0"},
+  %%{katana, "0.4.0"},
   {base64url, "0.0.1"}
 ]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,34 +1,20 @@
 {"1.1.0",
-[{<<"aleppo">>,{pkg,<<"inaka_aleppo">>,<<"1.0.0">>},3},
- {<<"base64url">>,{pkg,<<"base64url">>,<<"0.0.1">>},0},
+[{<<"base64url">>,{pkg,<<"base64url">>,<<"0.0.1">>},0},
  {<<"cowlib">>,
   {git,"https://github.com/ninenines/cowlib",
        {ref,"07cde7c6def6eeed0174b270229e7d5175673d87"}},
   1},
- {<<"elvis">>,{pkg,<<"elvis_core">>,<<"0.3.5">>},1},
- {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},3},
  {<<"gun">>,
   {git,"https://github.com/ninenines/gun.git",
        {ref,"bc733a2ca5f7d07f997ad6edf184f775b23434aa"}},
   0},
  {<<"jsx">>,{pkg,<<"jsx">>,<<"2.8.1">>},0},
- {<<"katana">>,{pkg,<<"katana">>,<<"0.4.0">>},0},
- {<<"katana_code">>,{pkg,<<"katana_code">>,<<"0.1.0">>},2},
- {<<"lager">>,{pkg,<<"lager">>,<<"3.2.4">>},2},
  {<<"ranch">>,
   {git,"https://github.com/ninenines/ranch",
        {ref,"a004ad710eddd0c21aaccc30d5633a76b06164b5"}},
-  1},
- {<<"zipper">>,{pkg,<<"zipper">>,<<"1.0.1">>},2}]}.
+  1}]}.
 [
 {pkg_hash,[
- {<<"aleppo">>, <<"8DB14CF16BB8C263C14FF4C3F69F64D7C849D40888944F4204D2CA74F1114CEB">>},
  {<<"base64url">>, <<"36A90125F5948E3AFD7BE97662A1504B934DD5DAC78451CA6E9ABF85A10286BE">>},
- {<<"elvis">>, <<"9C6DE2DA5317081D12512CA34EC9CAC858D3A169E6882E86BFAC97FA47962C4D">>},
- {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
- {<<"jsx">>, <<"1453B4EB3615ACB3E2CD0A105D27E6761E2ED2E501AC0B390F5BBEC497669846">>},
- {<<"katana">>, <<"8A26A45D4F13367AD70672F77EE6B9E4D3639750C55F1AE0F85A205A70D26396">>},
- {<<"katana_code">>, <<"C34F3926A258D6BEACD8D21F140F3D47D175501936431C460B144339D5271A0B">>},
- {<<"lager">>, <<"A6DEB74DAE7927F46BD13255268308EF03EB206EC784A94EAF7C1C0F3B811615">>},
- {<<"zipper">>, <<"3CCB4F14B97C06B2749B93D8B6C204A1ECB6FAFC6050CACC3B93B9870C05952A">>}]}
+ {<<"jsx">>, <<"1453B4EB3615ACB3E2CD0A105D27E6761E2ED2E501AC0B390F5BBEC497669846">>}]}
 ].

--- a/src/apns_utils.erl
+++ b/src/apns_utils.erl
@@ -38,7 +38,7 @@ sign(Data) ->
   Command = "printf '" ++
             binary_to_list(Data) ++
             "' | openssl dgst -binary -sha256 -sign " ++ KeyPath ++ " | base64",
-  {0, Result} = ktn_os:command(Command),
+  Result = os:cmd(Command),
   list_to_binary(Result).
 
 %% Retrieves the epoch date.


### PR DESCRIPTION
According to [kernel: Fix hanging os:cmd race condition](https://github.com/erlang/otp/commit/bf9f79e81530b37d5ac4abe1494f270986d92cb4) , the `os:cmd/1` is more robust. They both use `open_port`, but `os:cmd/1` adds `monitor`, make it more robust.