### PR TITLE
[#159] – Improve `apns_utils:sing/1` in order to use `os:cmd/1`.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -25,7 +25,6 @@
 {deps, [
   {gun, {git, "https://github.com/ninenines/gun.git", {branch, "master"}}},
   {jsx, "2.8.1"},
-  {katana, "0.4.0"},
   {base64url, "0.0.1"}
 ]}.
 
@@ -35,6 +34,7 @@
   {test, [
     {deps, [
       {katana_test, "0.1.1"},
+      {katana, "0.4.0"},
       {mixer, "0.1.5", {pkg, inaka_mixer}},
       {meck, "0.8.4"}
     ]}

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,34 +1,20 @@
 {"1.1.0",
-[{<<"aleppo">>,{pkg,<<"inaka_aleppo">>,<<"1.0.0">>},3},
- {<<"base64url">>,{pkg,<<"base64url">>,<<"0.0.1">>},0},
+[{<<"base64url">>,{pkg,<<"base64url">>,<<"0.0.1">>},0},
  {<<"cowlib">>,
   {git,"https://github.com/ninenines/cowlib",
        {ref,"07cde7c6def6eeed0174b270229e7d5175673d87"}},
   1},
- {<<"elvis">>,{pkg,<<"elvis_core">>,<<"0.3.5">>},1},
- {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},3},
  {<<"gun">>,
   {git,"https://github.com/ninenines/gun.git",
        {ref,"bc733a2ca5f7d07f997ad6edf184f775b23434aa"}},
   0},
  {<<"jsx">>,{pkg,<<"jsx">>,<<"2.8.1">>},0},
- {<<"katana">>,{pkg,<<"katana">>,<<"0.4.0">>},0},
- {<<"katana_code">>,{pkg,<<"katana_code">>,<<"0.1.0">>},2},
- {<<"lager">>,{pkg,<<"lager">>,<<"3.2.4">>},2},
  {<<"ranch">>,
   {git,"https://github.com/ninenines/ranch",
        {ref,"a004ad710eddd0c21aaccc30d5633a76b06164b5"}},
-  1},
- {<<"zipper">>,{pkg,<<"zipper">>,<<"1.0.1">>},2}]}.
+  1}]}.
 [
 {pkg_hash,[
- {<<"aleppo">>, <<"8DB14CF16BB8C263C14FF4C3F69F64D7C849D40888944F4204D2CA74F1114CEB">>},
  {<<"base64url">>, <<"36A90125F5948E3AFD7BE97662A1504B934DD5DAC78451CA6E9ABF85A10286BE">>},
- {<<"elvis">>, <<"9C6DE2DA5317081D12512CA34EC9CAC858D3A169E6882E86BFAC97FA47962C4D">>},
- {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
- {<<"jsx">>, <<"1453B4EB3615ACB3E2CD0A105D27E6761E2ED2E501AC0B390F5BBEC497669846">>},
- {<<"katana">>, <<"8A26A45D4F13367AD70672F77EE6B9E4D3639750C55F1AE0F85A205A70D26396">>},
- {<<"katana_code">>, <<"C34F3926A258D6BEACD8D21F140F3D47D175501936431C460B144339D5271A0B">>},
- {<<"lager">>, <<"A6DEB74DAE7927F46BD13255268308EF03EB206EC784A94EAF7C1C0F3B811615">>},
- {<<"zipper">>, <<"3CCB4F14B97C06B2749B93D8B6C204A1ECB6FAFC6050CACC3B93B9870C05952A">>}]}
+ {<<"jsx">>, <<"1453B4EB3615ACB3E2CD0A105D27E6761E2ED2E501AC0B390F5BBEC497669846">>}]}
 ].

--- a/src/apns_os.erl
+++ b/src/apns_os.erl
@@ -1,0 +1,38 @@
+%%% @doc Contains util functions.
+%%%
+%%% Copyright 2017 Erlang Solutions Ltd.
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%% @end
+%%% @copyright Inaka <hello@inaka.net>
+%%%
+-module(apns_os).
+
+% API
+-export([cmd/1]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec cmd(string()) -> {0 | 1, string()}.
+cmd(Cmd) ->
+  NewCmd = "
+    R=$(" ++ Cmd ++ ")\n
+    if [ $? -eq 0 ];then\n
+      echo \"0::$R\"\n
+    fi",
+  case string:tokens(os:cmd(NewCmd), "::") of
+    ["0", Result] -> {0, Result};
+    Error         -> {1, Error}
+  end.

--- a/src/apns_utils.erl
+++ b/src/apns_utils.erl
@@ -38,7 +38,7 @@ sign(Data) ->
   Command = "printf '" ++
             binary_to_list(Data) ++
             "' | openssl dgst -binary -sha256 -sign " ++ KeyPath ++ " | base64",
-  {0, Result} = ktn_os:command(Command),
+  {0, Result} = apns_os:cmd(Command),
   list_to_binary(Result).
 
 %% Retrieves the epoch date.

--- a/test/connection_SUITE.erl
+++ b/test/connection_SUITE.erl
@@ -200,7 +200,10 @@ push_notification_token(_Config) ->
              },
   Notification = #{<<"aps">> => #{<<"alert">> => <<"more messages">>}},
   DeviceId = <<"device_id2">>,
+
+  ok = maybe_mock_apns_os(),
   Token = apns:generate_token(<<"TeamId">>, <<"KeyId">>),
+
   ok = mock_gun_post(),
   ResponseCode = 200,
   ResponseHeaders = [{<<"apns-id">>, <<"apnsid2">>}],
@@ -218,8 +221,9 @@ push_notification_token(_Config) ->
                                 , DeviceId
                                 , Notification
                                 ),
+
   ok = close_connection(ConnectionName),
-  [_] = meck:unload(),
+  _ = meck:unload(),
   ok.
 
 -spec push_notification_timeout(config()) -> ok.
@@ -314,7 +318,6 @@ mock_gun_open() ->
     {ok, spawn(fun test_function/0)}
   end).
 
-
 -spec mock_gun_post() -> ok.
 mock_gun_post() ->
   meck:expect(gun, post, fun(_, _, _, _) ->
@@ -337,6 +340,14 @@ mock_gun_await_body(Body) ->
 mock_gun_await_up(Result) ->
   meck:expect(gun, await_up, fun(_, _) ->
     Result
+  end).
+
+-spec maybe_mock_apns_os() -> ok.
+maybe_mock_apns_os() ->
+  %% @TODO: Add logic to validate if the user wants to avoid to mock this call,
+  %% and make the real call with real files instead.
+  meck:expect(apns_os, cmd, fun(_) ->
+    {0, "12345678"}
   end).
 
 close_connection(ConnectionName) ->


### PR DESCRIPTION
[#159] – Improve `apns_utils:sing/1` in order to use `os:cmd/1`.