### PR TITLE
Allow binary cert/key in apns_connection like v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The other way is send all that info as a parameter to `apns:connect/1` function 
  }.
 ```
 
-APNs allows two connection types, one is using `Provider Certificates`. If you want to use that way make sure you fill the `certfile` and `keyfile`. Those are paths to the `Provider Certificated` and the `Private Key` both provided by Apple. We need them in `.pem` format, here is an example of how to convert them, check the [certificates](https://blog.serverdensity.com/how-to-build-an-apple-push-notification-provider-server-tutorial/) section.
+APNs allows two connection types, one is using `Provider Certificates`. The first certificate option is to supply cert paths in `certfile` and `keyfile`. Alternatively, you can supply a cert binary in `certdata` and a `keydata()`-type tuple (see: https://github.com/inaka/apns4erl/blob/master/src/apns_connection.erl#L64) in `keydata`. Certs are the `Provider Certificates` and the keys are the `Private Key` both provided by Apple. We need them in `.pem` format, here is an example of how to convert them, check the [certificates](https://blog.serverdensity.com/how-to-build-an-apple-push-notification-provider-server-tutorial/) section.
 
 The other way to connect against APNs is using `Provider Authentication Tokens`, for this choice you must fill the field `token_keyfile`. This is a path to the Authentication Key provided by Apple. This is in `.p8` format and it doesn't need conversion.
 
@@ -101,13 +101,15 @@ After running `apns4erl` app we can start creating connections. As we mentioned 
   #{ name       := name()
    , apple_host := host()
    , apple_port := inet:port_number()
+   , certdata   => binary()
    , certfile   => path()
+   , keydata    => keydata()
    , keyfile    => path()
    , timeout    => integer()
    , type       := type()
    }.
   ```
-  where the `type` field indicates if is `cert` or `token`.
+  where the `type` field indicates if is `certdata`, `cert`, or `token`.
 
 - `apns:connect/2`: The first argument is the type and the second one is the connection's name. In order to use it successfully we have to fill the `config` file before, as explained in `how to use it?` section.
 

--- a/src/apns_connection.erl
+++ b/src/apns_connection.erl
@@ -61,8 +61,9 @@
 -type path()         :: string().
 -type notification() :: binary().
 -type type()         :: certdata | cert | token.
--type keydata()      :: {'RSAPrivateKey' | 'DSAPrivateKey' | 'ECPrivateKey' | 'PrivateKeyInfo'
-                        ,binary()}.
+-type keydata()      :: {'RSAPrivateKey' | 'DSAPrivateKey' | 'ECPrivateKey' |
+                         'PrivateKeyInfo'
+                        , binary()}.
 -type connection()   :: #{ name       := name()
                          , apple_host := host()
                          , apple_port := inet:port_number()

--- a/src/apns_connection.erl
+++ b/src/apns_connection.erl
@@ -27,9 +27,9 @@
         , name/1
         , host/1
         , port/1
-        , cert/1
+        , certdata/1
         , certfile/1
-        , key/1
+        , keydata/1
         , keyfile/1
         , type/1
         , http2_connection/1
@@ -278,16 +278,16 @@ host(#{apple_host := Host}) ->
 port(#{apple_port := Port}) ->
   Port.
 
--spec cert(connection()) -> binary().
-cert(#{certdata := Cert}) ->
+-spec certdata(connection()) -> binary().
+certdata(#{certdata := Cert}) ->
   Cert.
 
 -spec certfile(connection()) -> path().
 certfile(#{certfile := Certfile}) ->
   Certfile.
 
--spec key(connection()) -> keydata().
-key(#{keydata := Key}) ->
+-spec keydata(connection()) -> keydata().
+keydata(#{keydata := Key}) ->
   Key.
 
 -spec keyfile(connection()) -> path().
@@ -308,8 +308,8 @@ open_http2_connection(Connection) ->
 
   TransportOpts = case type(Connection) of
     certdata ->
-      Cert = cert(Connection),
-      Key = key(Connection),
+      Cert = certdata(Connection),
+      Key = keydata(Connection),
       [{cert, Cert}, {key, Key}];
     cert ->
       Certfile = certfile(Connection),

--- a/src/apns_connection.erl
+++ b/src/apns_connection.erl
@@ -27,7 +27,9 @@
         , name/1
         , host/1
         , port/1
+        , cert/1
         , certfile/1
+        , key/1
         , keyfile/1
         , type/1
         , http2_connection/1
@@ -58,11 +60,15 @@
 -type host()         :: string() | inet:ip_address().
 -type path()         :: string().
 -type notification() :: binary().
--type type()         :: cert | token.
+-type type()         :: certdata | cert | token.
+-type keydata()      :: {'RSAPrivateKey' | 'DSAPrivateKey' | 'ECPrivateKey' | 'PrivateKeyInfo'
+                        ,binary()}.
 -type connection()   :: #{ name       := name()
                          , apple_host := host()
                          , apple_port := inet:port_number()
+                         , certdata   => binary()
                          , certfile   => path()
+                         , keydata    => keydata()
                          , keyfile    => path()
                          , timeout    => integer()
                          , type       := type()
@@ -90,6 +96,21 @@ start_link(Connection, Client) ->
 
 %% @doc Builds a connection() map from the environment variables.
 -spec default_connection(type(), name()) -> connection().
+default_connection(certdata, ConnectionName) ->
+  {ok, Host} = application:get_env(apns, apple_host),
+  {ok, Port} = application:get_env(apns, apple_port),
+  {ok, Cert} = application:get_env(apns, certdata),
+  {ok, Key} = application:get_env(apns, keydata),
+  {ok, Timeout} = application:get_env(apns, timeout),
+
+  #{ name       => ConnectionName
+   , apple_host => Host
+   , apple_port => Port
+   , certdata   => Cert
+   , keydata    => Key
+   , timeout    => Timeout
+   , type       => certdata
+  };
 default_connection(cert, ConnectionName) ->
   {ok, Host} = application:get_env(apns, apple_host),
   {ok, Port} = application:get_env(apns, apple_port),
@@ -256,9 +277,17 @@ host(#{apple_host := Host}) ->
 port(#{apple_port := Port}) ->
   Port.
 
+-spec cert(connection()) -> binary().
+cert(#{certdata := Cert}) ->
+  Cert.
+
 -spec certfile(connection()) -> path().
 certfile(#{certfile := Certfile}) ->
   Certfile.
+
+-spec key(connection()) -> keydata().
+key(#{keydata := Key}) ->
+  Key.
 
 -spec keyfile(connection()) -> path().
 keyfile(#{keyfile := Keyfile}) ->
@@ -277,6 +306,10 @@ open_http2_connection(Connection) ->
   Host = host(Connection),
 
   TransportOpts = case type(Connection) of
+    certdata ->
+      Cert = cert(Connection),
+      Key = key(Connection),
+      [{cert, Cert}, {key, Key}];
     cert ->
       Certfile = certfile(Connection),
       Keyfile = keyfile(Connection),

--- a/test/connection_SUITE.erl
+++ b/test/connection_SUITE.erl
@@ -7,6 +7,7 @@
         ]).
 
 -export([ default_connection/1
+        , certdata_keydata_connection/1
         , connect/1
         , connect_without_name/1
         , http2_connection_lost/1
@@ -26,6 +27,7 @@
 
 -spec all() -> [atom()].
 all() ->  [ default_connection
+          , certdata_keydata_connection
           , connect
           , connect_without_name
           , http2_connection_lost
@@ -77,6 +79,24 @@ default_connection(_Config) ->
   token = apns_connection:type(DefaultConnection2),
   ok.
 
+-spec certdata_keydata_connection(config()) -> ok.
+certdata_keydata_connection(_Config) ->
+  ConnectionName = my_connection2,
+  {ok, Host} = application:get_env(apns, apple_host),
+  {ok, Port} = application:get_env(apns, apple_port),
+  {ok, Certdata} = application:get_env(apns, certdata),
+  {ok, Keydata} = application:get_env(apns, keydata),
+
+  % certdata type connection
+  DefaultConnection = apns_connection:default_connection(certdata, ConnectionName),
+  ConnectionName = apns_connection:name(DefaultConnection),
+  Host = apns_connection:host(DefaultConnection),
+  Port = apns_connection:port(DefaultConnection),
+  Certdata = apns_connection:certdata(DefaultConnection),
+  Keydata = apns_connection:keydata(DefaultConnection),
+  certdata = apns_connection:type(DefaultConnection),
+  ok.
+
 -spec connect(config()) -> ok.
 connect(_Config) ->
   ok = mock_open_http2_connection(),
@@ -101,7 +121,7 @@ connect_without_name(_Config) ->
 -spec http2_connection_lost(config()) -> ok.
 http2_connection_lost(_Config) ->
   ok = mock_open_http2_connection(),
-  ConnectionName = my_connection2,
+  ConnectionName = my_connection3,
   {ok, ServerPid}  = apns:connect(cert, ConnectionName),
 
   HTTP2Conn = apns_connection:http2_connection(ConnectionName),
@@ -120,7 +140,7 @@ http2_connection_lost(_Config) ->
   % Repeat with ceiling 0, for testing coverage
   ok = application:set_env(apns, backoff_ceiling, 0),
 
-  ConnectionName2 = my_connection3,
+  ConnectionName2 = my_connection4,
   {ok, ServerPid2}  = apns:connect(cert, ConnectionName2),
   HTTP2Conn3 = apns_connection:http2_connection(ConnectionName2),
   true = is_process_alive(HTTP2Conn3),

--- a/test/test.config
+++ b/test/test.config
@@ -3,7 +3,9 @@
    apns,
    [ {apple_host,       "api.development.push.apple.com"}
    , {apple_port,       443}
+   , {certdata,         "DUMMY"}
    , {certfile,         "priv/apns-dev-cert.pem"}
+   , {keydata,          "DUMMY"}
    , {keyfile,          "priv/apns-dev-key-noenc.pem"}
    , {token_keyfile,    "priv/APNsAuthKey_KEYID12345.p8"}
    , {timeout,          10000}


### PR DESCRIPTION
We store the APNS provider cert/key in a shared database, so we prefer to be able to supply this information directly to the apns4erl library, avoiding a file on disk.
This PR adds back support (previously in v1) to set cert/key binary data on the apns_connection.