### PR TITLE
Make the location of OpenSSL configurable

### DIFF
--- a/src/apns.app.src
+++ b/src/apns.app.src
@@ -13,6 +13,9 @@
   ]},
   {modules, []},
   {mod, {apns_app, []}},
+  {env, [
+      {openssl_path, "openssl"}
+  ]},
   {maintainers,["Inaka"]},
   {licenses,["Apache 2.0"]},
   {links,[{"Github","https://github.com/inaka/apns4erl"}]},

--- a/src/apns_utils.erl
+++ b/src/apns_utils.erl
@@ -35,9 +35,10 @@
 -spec sign(binary()) -> binary().
 sign(Data) ->
   {ok, KeyPath} = application:get_env(apns, token_keyfile),
+  {ok, Openssl} = application:get_env(apns, openssl_path),
   Command = "printf '" ++
             binary_to_list(Data) ++
-            "' | openssl dgst -binary -sha256 -sign " ++ KeyPath ++ " | base64",
+            "' | " ++ Openssl ++ " dgst -binary -sha256 -sign " ++ KeyPath ++ " | base64",
   {0, Result} = apns_os:cmd(Command),
   strip_b64(list_to_binary(Result)).
 
@@ -67,3 +68,4 @@ seconds_to_timestamp(Secs) ->
 -spec strip_b64(binary()) -> binary().
 strip_b64(BS) ->
   binary:list_to_bin(binary:split(BS, [<<"\n">>, <<"=">>], [global])).
+


### PR DESCRIPTION
Apple devices as well as older software installations of Linux are
likely to have too old OpenSSLs for the token signing to work. Fix
this by making the location of the OpenSSL binary configurable in the
configuration knobs.

We needed this patch for two reasons: Apple, and older Linux distributions. I'm just suggesting it as a patch for now, and I think the `_path` component is a bad name. Probably rather call it `openssl_executable` or something such. Also, it needs documentation.

However, if those things were fixed, would you guys be willing to take this patch in?