### PR TITLE
Use master branch of chatterbox

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,7 @@
 %% == Dependencies ==
 
 {deps, [
-  {chatterbox, "0.5.0"},
+  {chatterbox, {git, "https://github.com/joedevivo/chatterbox.git", {branch, "master"}}},
   {jsx, "2.8.2"},
   {base64url, "0.0.1"}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,9 @@
 {"1.1.0",
 [{<<"base64url">>,{pkg,<<"base64url">>,<<"0.0.1">>},0},
- {<<"chatterbox">>,{pkg,<<"chatterbox">>,<<"0.5.0">>},0},
+ {<<"chatterbox">>,
+  {git,"https://github.com/joedevivo/chatterbox.git",
+       {ref,"f5b68963bc63b3b2cf8701fafe61cfae9c0a383f"}},
+  0},
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},2},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},1},
  {<<"jsx">>,{pkg,<<"jsx">>,<<"2.8.2">>},0},
@@ -8,7 +11,6 @@
 [
 {pkg_hash,[
  {<<"base64url">>, <<"36A90125F5948E3AFD7BE97662A1504B934DD5DAC78451CA6E9ABF85A10286BE">>},
- {<<"chatterbox">>, <<"69F5A1F36F905472B7662A301E67309DD3CAE7D0CA1B2E52C14D43EE7DF4C3A3">>},
  {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
  {<<"hpack">>, <<"17670F83FF984AE6CD74B1C456EDDE906D27FF013740EE4D9EFAA4F1BF999633">>},
  {<<"jsx">>, <<"7ACC7D785B5ABE8A6E9ADBDE926A24E481F29956DD8B4DF49E3E4E7BCC92A018">>},


### PR DESCRIPTION
Chatterbox in version 0.5.0 has a memory leak which has been there
since at least December 2016. The problem is that finished HTTP/2
streams are not cleared out properly when you get their response. This
means the Chatterbox process will keep allocating more and more
memory as time goes on and eventually crash the Erlang node.

Use the git-version of Chatterbox for now, which has the fix in place.
This avoids memleaks of this kind.