### PR TITLE
Switch apns to use Gun, add support for CONNECT proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,28 +236,10 @@ process which created the connection. If we try to do it from a different one we
 
 ## Reconnection
 
-If something unexpected happens and the `chatterbox` connection with APNs crashes `apns4erl` will send a message `{reconnecting, ServerPid}` to the client process, that means `apns4erl` lost the connection and it is trying to reconnect. Once the connection has been recover a `{connection_up, ServerPid}` message will be send.
+If network goes down or something unexpected happens the `gun` connection with APNs will go down. In that case `apns4erl` will send a message `{reconnecting, ServerPid}` to the client process, that means `apns4erl` lost the connection and it is trying to reconnect. Once the connection has been recover a `{connection_up, ServerPid}` message will be send.
+
 
 We implemented an *Exponential Backoff* strategy. We can set the *ceiling* time adding the `backoff_ceiling` variable on the `config` file. By default it is set to 10 (seconds).
-
-## Timeout
-
-When we call `apns:push_notification/3,4` or `apns:push_notification_token/4,5` we could get a `timeout` that could be caused if the network went down. Here is the `timeout` format:
-
-```erlang
-{timeout, stream_id()}
-```
-where that `stream_id()` is an identifier for the notification.
-
-
-Getting a `timeout` doesn't mean your notification to APNs is lost. If `apns4erl` connects to network again it will try to send your notification, in that case `apns4erl` will send back a message to the client with the format:
-
-```erlang
-{apns_response, ServerPid, StreamID, Response}
-```
-where that StreamId should match with the `stream_id` we got on the `timeout` tuple.
-
-You should check your client inbox after a timeout but it is not guaranteed your message was send successfully.
 
 ## Close connections
 

--- a/elvis.config
+++ b/elvis.config
@@ -6,7 +6,10 @@
      [#{dirs => ["src", "test"],
         filter => "*.erl",
         ruleset => erl_files,
-        rules => [{elvis_style, line_length, #{limit => 100}}]
+        rules => [
+            {elvis_style, line_length, #{limit => 100}}
+          , {elvis_style, god_modules, #{limit => 25, ignore => [apns_connection]}}
+          ]
        },
       #{dirs => ["."],
         filter => "Makefile",

--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,7 @@
 %% == Dependencies ==
 
 {deps, [
-  {chatterbox, "0.7.0"},
+  {gun, "1.3.0"},
   {jsx, "2.9.0"},
   {base64url, "0.0.1"}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,12 +1,12 @@
 {"1.1.0",
 [{<<"base64url">>,{pkg,<<"base64url">>,<<"0.0.1">>},0},
- {<<"chatterbox">>,{pkg,<<"chatterbox">>,<<"0.7.0">>},0},
- {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},1},
+ {<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.6.0">>},1},
+ {<<"gun">>,{pkg,<<"gun">>,<<"1.3.0">>},0},
  {<<"jsx">>,{pkg,<<"jsx">>,<<"2.9.0">>},0}]}.
 [
 {pkg_hash,[
  {<<"base64url">>, <<"36A90125F5948E3AFD7BE97662A1504B934DD5DAC78451CA6E9ABF85A10286BE">>},
- {<<"chatterbox">>, <<"8036197E00C42B3AC401DABDA722FD211071B27CBD59A7CEA471185F5D1F573A">>},
- {<<"hpack">>, <<"17670F83FF984AE6CD74B1C456EDDE906D27FF013740EE4D9EFAA4F1BF999633">>},
+ {<<"cowlib">>, <<"8AA629F81A0FC189F261DC98A42243FA842625FEEA3C7EC56C48F4CCDB55490F">>},
+ {<<"gun">>, <<"18E5D269649C987AF95AEC309F68A27FFC3930531DD227A6EAA0884D6684286E">>},
  {<<"jsx">>, <<"D2F6E5F069C00266CAD52FB15D87C428579EA4D7D73A33669E12679E203329DD">>}]}
 ].

--- a/src/apns.app.src
+++ b/src/apns.app.src
@@ -8,7 +8,7 @@
     kernel,
     stdlib,
     jsx,
-    chatterbox,
+    gun,
     base64url
   ]},
   {modules, []},

--- a/src/apns.erl
+++ b/src/apns.erl
@@ -77,7 +77,7 @@ stop() ->
 
 %% @doc Connects to APNs service with Provider Certificate or Token
 -spec connect( apns_connection:type(), apns_connection:name()) ->
-  {ok, pid()} | {error, timeout}.
+  {ok, pid()}.
 connect(Type, ConnectionName) ->
   DefaultConnection = apns_connection:default_connection(Type, ConnectionName),
   connect(DefaultConnection).
@@ -88,7 +88,7 @@ connect(Connection) ->
   apns_sup:create_connection(Connection).
 
 %% @doc Wait for the APNs connection to be up.
--spec wait_for_connection_up(pid()) -> ok | {error, timeout}.
+-spec wait_for_connection_up(pid()) -> ok.
 wait_for_connection_up(Server) ->
   apns_connection:wait_apns_connection_up(Server).
 

--- a/src/apns.erl
+++ b/src/apns.erl
@@ -24,6 +24,7 @@
         , stop/0
         , connect/1
         , connect/2
+        , wait_for_connection_up/1
         , close_connection/1
         , push_notification/3
         , push_notification/4
@@ -40,16 +41,14 @@
              , response/0
              , token/0
              , headers/0
-             , stream_id/0
              ]).
 
--type json()      :: #{binary() | atom() => binary() | json()}.
+-type json()      :: #{binary() => binary() | json()}.
 -type device_id() :: binary().
--type stream_id() :: integer().
 -type response()  :: { integer()          % HTTP2 Code
                      , [term()]           % Response Headers
                      , [term()] | no_body % Response Body
-                     } | {timeout, stream_id()}.
+                     } | timeout.
 -type token()     :: binary().
 -type headers()   :: #{ apns_id          => binary()
                       , apns_expiration  => binary()
@@ -84,9 +83,14 @@ connect(Type, ConnectionName) ->
   connect(DefaultConnection).
 
 %% @doc Connects to APNs service
--spec connect(apns_connection:connection()) -> {ok, pid()} | {error, timeout}.
+-spec connect(apns_connection:connection()) -> {ok, pid()}.
 connect(Connection) ->
   apns_sup:create_connection(Connection).
+
+%% @doc Wait for the APNs connection to be up.
+-spec wait_for_connection_up(pid()) -> ok | {error, timeout}.
+wait_for_connection_up(Server) ->
+  apns_connection:wait_apns_connection_up(Server).
 
 %% @doc Closes the connection with APNs service.
 -spec close_connection(apns_connection:name() | pid()) -> ok.

--- a/src/apns_connection.erl
+++ b/src/apns_connection.erl
@@ -1,4 +1,4 @@
-%%% @doc This gen_server handles the APNs Connection.
+%%% @doc This gen_statem handles the APNs Connection.
 %%%
 %%% Copyright 2017 Erlang Solutions Ltd.
 %%%
@@ -19,7 +19,7 @@
 -module(apns_connection).
 -author("Felipe Ripoll <felipe@inakanetworks.com>").
 
--behaviour(gen_server).
+-behaviour(gen_statem).
 
 %% API
 -export([ start_link/2
@@ -32,20 +32,26 @@
         , keydata/1
         , keyfile/1
         , type/1
-        , gun_connection/1
+        , gun_pid/1
         , close_connection/1
         , push_notification/4
         , push_notification/5
         , wait_apns_connection_up/1
         ]).
 
-%% gen_server callbacks
+%% gen_statem callbacks
 -export([ init/1
-        , handle_call/3
-        , handle_cast/2
-        , handle_info/2
-        , terminate/2
-        , code_change/3
+        , callback_mode/0
+        , open_connection/3
+        , open_origin/3
+        , open_proxy/3
+        , open_common/3
+        , await_up/3
+        , proxy_connect_to_origin/3
+        , await_tunnel_up/3
+        , connected/3
+        , down/3
+        , code_change/4
         ]).
 
 -export_type([ name/0
@@ -65,6 +71,12 @@
 -type keydata()      :: {'RSAPrivateKey' | 'DSAPrivateKey' | 'ECPrivateKey' |
                          'PrivateKeyInfo'
                         , binary()}.
+-type proxy_info()   :: #{ type       := connect
+                         , host       := host()
+                         , port       := inet:port_number()
+                         , username   => iodata()
+                         , password   => iodata()
+                         }.
 -type connection()   :: #{ name       := name()
                          , apple_host := host()
                          , apple_port := inet:port_number()
@@ -74,10 +86,13 @@
                          , keyfile    => path()
                          , timeout    => integer()
                          , type       := type()
+                         , proxy_info => proxy_info()
                          }.
 
 -type state()        :: #{ connection      := connection()
-                         , gun_connection  := pid()
+                         , gun_pid         => pid()
+                         , gun_monitor     => reference()
+                         , gun_connect_ref => reference()
                          , client          := pid()
                          , backoff         := non_neg_integer()
                          , backoff_ceiling := non_neg_integer()
@@ -87,14 +102,14 @@
 %%% API
 %%%===================================================================
 
-%% @doc starts the gen_server
+%% @doc starts the gen_statem
 -spec start_link(connection(), pid()) ->
   {ok, Pid :: pid()} | ignore | {error, Reason :: term()}.
 start_link(#{name := undefined} = Connection, Client) ->
-  gen_server:start_link(?MODULE, {Connection, Client}, []);
+  gen_statem:start_link(?MODULE, {Connection, Client}, []);
 start_link(Connection, Client) ->
   Name = name(Connection),
-  gen_server:start_link({local, Name}, ?MODULE, {Connection, Client}, []).
+  gen_statem:start_link({local, Name}, ?MODULE, {Connection, Client}, []).
 
 %% @doc Builds a connection() map from the environment variables.
 -spec default_connection(type(), name()) -> connection().
@@ -143,12 +158,12 @@ default_connection(token, ConnectionName) ->
 %% @doc Close the connection with APNs gracefully
 -spec close_connection(name() | pid()) -> ok.
 close_connection(ConnectionId) ->
-  gen_server:cast(ConnectionId, stop).
+  gen_statem:cast(ConnectionId, stop).
 
 %% @doc Returns the gun's connection PID. This function is only used in tests.
--spec gun_connection(name() | pid()) -> pid().
-gun_connection(ConnectionId) ->
-  gen_server:call(ConnectionId, gun_connection).
+-spec gun_pid(name() | pid()) -> pid().
+gun_pid(ConnectionId) ->
+  gen_statem:call(ConnectionId, gun_pid).
 
 %% @doc Pushes notification to certificate APNs connection.
 -spec push_notification( name() | pid()
@@ -156,7 +171,7 @@ gun_connection(ConnectionId) ->
                        , notification()
                        , apns:headers()) -> apns:response() | {error, not_connection_owner}.
 push_notification(ConnectionId, DeviceId, Notification, Headers) ->
-  gen_server:call(ConnectionId, {push_notification, DeviceId, Notification, Headers}).
+  gen_statem:call(ConnectionId, {push_notification, DeviceId, Notification, Headers}).
 
 %% @doc Pushes notification to certificate APNs connection.
 -spec push_notification( name() | pid()
@@ -165,121 +180,206 @@ push_notification(ConnectionId, DeviceId, Notification, Headers) ->
                        , notification()
                        , apns:headers()) -> apns:response() | {error, not_connection_owner}.
 push_notification(ConnectionId, Token, DeviceId, Notification, Headers) ->
-  gen_server:call(ConnectionId, {push_notification, Token, DeviceId, Notification, Headers}).
+  gen_statem:call(ConnectionId, {push_notification, Token, DeviceId, Notification, Headers}).
 
-%% @doc Waits until receive the `connection_up` message
--spec wait_apns_connection_up(pid()) -> ok | {error, timeout}.
+%% @doc Waits until the APNS connection is up.
+%%
+%% Note that this function does not need to be called before
+%% sending push notifications, since they will be queued up
+%% and sent when the connection is established.
+-spec wait_apns_connection_up(pid()) -> ok.
 wait_apns_connection_up(Server) ->
-  receive
-    {connection_up, Server} -> ok;
-    {timeout, Server}       -> {error, timeout}
-  end.
+  gen_statem:call(Server, wait_apns_connection_up, infinity).
 
 %%%===================================================================
-%%% gen_server callbacks
+%%% gen_statem callbacks
 %%%===================================================================
 
--spec init({connection(), pid()}) -> {ok, State :: state(), timeout()}.
+-spec callback_mode() -> state_functions.
+callback_mode() -> state_functions.
+
+-spec init({connection(), pid()})
+  -> { ok
+     , open_connection
+     , State :: state()
+     , {next_event, internal, init}
+     }.
 init({Connection, Client}) ->
-  GunConnectionPid = open_gun_connection(Connection),
+  StateData = #{ connection      => Connection
+               , client          => Client
+               , backoff         => 1
+               , backoff_ceiling => application:get_env(apns, backoff_ceiling, 10)
+               },
+  {ok, open_connection, StateData,
+    {next_event, internal, init}}.
 
-  {ok, #{ connection      => Connection
-        , gun_connection  => GunConnectionPid
-        , client          => Client
-        , backoff         => 1
-        , backoff_ceiling => application:get_env(apns, backoff_ceiling, 10)
-        }, 0}.
+-spec open_connection(_, _, _) -> _.
+open_connection(internal, _, #{connection := Connection} = StateData) ->
+  NextState = case proxy(Connection) of
+    #{type := connect} -> open_proxy;
+    undefined          -> open_origin
+  end,
+  {next_state, NextState, StateData,
+    {next_event, internal, init}}.
 
--spec handle_call( Request :: term(), From :: {pid(), term()}, State) ->
-  {reply, term(), State}.
-handle_call(gun_connection, _From, #{gun_connection := GunConn} = State) ->
-  {reply, GunConn, State};
-handle_call( {push_notification, DeviceId, Notification, Headers}
-           , {From, _}
-           , #{client := From} = State) ->
-  #{connection := Connection, gun_connection := GunConn} = State,
+-spec open_origin(_, _, _) -> _.
+open_origin(internal, _, #{connection := Connection} = StateData) ->
+  Host = host(Connection),
+  Port = port(Connection),
+  TransportOpts = transport_opts(Connection),
+  {next_state, open_common, StateData,
+    {next_event, internal, { Host
+                           , Port
+                           , #{ protocols      => [http2]
+                              , transport_opts => TransportOpts
+                              , retry          => 0
+                              }}}}.
+
+-spec open_proxy(_, _, _) -> _.
+open_proxy(internal, _, StateData) ->
+  #{connection := Connection} = StateData,
+  #{type := connect, host := ProxyHost, port := ProxyPort} = proxy(Connection),
+  {next_state, open_common, StateData,
+    {next_event, internal, { ProxyHost
+                           , ProxyPort
+                           , #{ protocols => [http]
+                              , transport => tcp
+                              , retry     => 0
+                              }}}}.
+
+%% This function exists only to make Elvis happy.
+%% I do not think it makes things any easier to read.
+-spec open_common(_, _, _) -> _.
+open_common(internal, {Host, Port, Opts}, StateData) ->
+  {ok, GunPid} = gun:open(Host, Port, Opts),
+  GunMon = monitor(process, GunPid),
+  {next_state, await_up,
+    StateData#{gun_pid => GunPid, gun_monitor => GunMon},
+    {state_timeout, 15000, open_timeout}}.
+
+-spec await_up(_, _, _) -> _.
+await_up(info, {gun_up, GunPid, Protocol}, #{gun_pid := GunPid} = StateData) ->
+  #{connection := Connection} = StateData,
+  NextState = case proxy(Connection) of
+    #{type := connect} when Protocol =:= http -> proxy_connect_to_origin;
+    undefined when Protocol =:= http2 -> connected
+  end,
+  {next_state, NextState, StateData,
+    {next_event, internal, on_connect}};
+await_up(EventType, EventContent, StateData) ->
+  handle_common(EventType, EventContent, ?FUNCTION_NAME, StateData, postpone).
+
+-spec proxy_connect_to_origin(_, _, _) -> _.
+proxy_connect_to_origin(internal, on_connect, StateData) ->
+  #{connection := Connection, gun_pid := GunPid} = StateData,
+  Host = host(Connection),
+  Port = port(Connection),
+  TransportOpts = transport_opts(Connection),
+  Destination0 = #{ host => Host
+                  , port => Port
+                  , protocol => http2
+                  , transport => tls
+                  , tls_opts => TransportOpts
+                  },
+  Destination = case proxy(Connection) of
+    #{ username := Username, password := Password } ->
+      Destination0#{ username => Username, password => Password };
+    _ ->
+      Destination0
+  end,
+  ConnectRef = gun:connect(GunPid, Destination),
+  {next_state, await_tunnel_up, StateData#{gun_connect_ref => ConnectRef},
+    {state_timeout, 30000, proxy_connect_timeout}}.
+
+-spec await_tunnel_up(_, _, _) -> _.
+await_tunnel_up( info
+               , {gun_response, GunPid, ConnectRef, fin, 200, _}
+               , #{gun_pid := GunPid, gun_connect_ref := ConnectRef} = StateData) ->
+  {next_state, connected, StateData,
+    {next_event, internal, on_connect}};
+await_tunnel_up(EventType, EventContent, StateData) ->
+  handle_common(EventType, EventContent, ?FUNCTION_NAME, StateData, postpone).
+
+-spec connected(_, _, _) -> _.
+connected(internal, on_connect, #{client := Client}) ->
+  Client ! {connection_up, self()},
+  keep_state_and_data;
+connected( {call, {Client, _} = From}
+         , {push_notification, DeviceId, Notification, Headers}
+         , #{client := Client} = StateData) ->
+  #{connection := Connection, gun_pid := GunPid} = StateData,
   #{timeout := Timeout} = Connection,
-  Response = push(GunConn, DeviceId, Headers, Notification, Timeout),
-  {reply, Response, State};
-handle_call( {push_notification, Token, DeviceId, Notification, HeadersMap}
-           , {From, _}
-           , #{client := From} = State) ->
-  #{connection := Connection, gun_connection := GunConn} = State,
+  Response = push(GunPid, DeviceId, Headers, Notification, Timeout),
+  {keep_state_and_data, {reply, From, Response}};
+connected( {call, {Client, _} = From}
+         , {push_notification, Token, DeviceId, Notification, Headers0}
+         , #{client := Client} = StateData) ->
+  #{connection := Connection, gun_pid := GunConn} = StateData,
   #{timeout := Timeout} = Connection,
-  Headers = add_authorization_header(HeadersMap, Token),
+  Headers = add_authorization_header(Headers0, Token),
   Response = push(GunConn, DeviceId, Headers, Notification, Timeout),
-  {reply, Response, State};
-handle_call( {push_notification, _, _, _}, _From, State) ->
-  {reply, {error, not_connection_owner}, State};
-handle_call( {push_notification, _, _, _, _}, _From, State) ->
-  {reply, {error, not_connection_owner}, State};
-handle_call(_Request, _From, State) ->
-  {reply, ok, State}.
+  {keep_state_and_data, {reply, From, Response}};
+connected({call, From}, Event, _) when element(1, Event) =:= push_notification ->
+  {keep_state_and_data, {reply, From, {error, not_connection_owner}}};
+connected({call, From}, wait_apns_connection_up, _) ->
+  {keep_state_and_data, {reply, From, ok}};
+connected({call, From}, Event, _) when Event =/= gun_pid ->
+  {keep_state_and_data, {reply, From, {error, bad_call}}};
+connected(EventType, EventContent, StateData) ->
+  handle_common(EventType, EventContent, ?FUNCTION_NAME, StateData, drop).
 
--spec handle_cast(Request :: term(), State) ->
-  {noreply, State}.
-handle_cast(stop, State) ->
-  {stop, normal, State};
-handle_cast(_Request, State) ->
-  {noreply, State}.
-
--spec handle_info(Info :: timeout() | term(), State) -> {noreply, State}.
-handle_info( {gun_down, GunConn, http2, closed, _, _}
-           , #{ gun_connection  := GunConn
-              , client          := Client
-              , backoff         := Backoff
-              , backoff_ceiling := Ceiling
-              } = State) ->
-  ok = gun:close(GunConn),
+-spec down(_, _, _) -> _.
+down(internal
+    , _
+    , #{ gun_pid         := GunPid
+       , gun_monitor     := GunMon
+       , client          := Client
+       , backoff         := Backoff
+       , backoff_ceiling := Ceiling
+       }) ->
+  true = demonitor(GunMon, [flush]),
+  gun:close(GunPid),
   Client ! {reconnecting, self()},
-  Sleep = backoff(Backoff, Ceiling) * 1000, % seconds to wait before reconnect
-  {ok, _} = timer:send_after(Sleep, reconnect),
-  {noreply, State#{backoff => Backoff + 1}};
-handle_info(reconnect, State) ->
-  #{ connection      := Connection
-   , client          := Client
-   , backoff         := Backoff
-   , backoff_ceiling := Ceiling
-   } = State,
-  GunConn = open_gun_connection(Connection),
-  #{timeout := Timeout} = Connection,
-  case gun:await_up(GunConn, Timeout) of
-    {ok, http2} ->
-      Client ! {connection_up, self()},
-      {noreply, State#{ gun_connection => GunConn
-                      , backoff        => 1}};
-    {error, timeout} ->
-      ok = gun:close(GunConn),
-      Sleep = backoff(Backoff, Ceiling) * 1000, % seconds to wait
-      {ok, _} = timer:send_after(Sleep, reconnect),
-      {noreply, State#{backoff => Backoff + 1}}
-  end;
-handle_info(timeout, #{connection := Connection, gun_connection := GunConn,
-                       client := Client} = State) ->
-  #{timeout := Timeout} = Connection,
-  case gun:await_up(GunConn, Timeout) of
-    {ok, http2} ->
-      Client ! {connection_up, self()},
-      {noreply, State};
-    {error, timeout} ->
-      Client ! {timeout, self()},
-      {stop, timeout, State}
-  end;
-handle_info(_Info, State) ->
-  {noreply, State}.
+  Sleep = backoff(Backoff, Ceiling) * 1000,
+  {keep_state_and_data, {state_timeout, Sleep, backoff}};
+down(state_timeout, backoff, StateData) ->
+  {next_state, open_connection, StateData,
+    {next_event, internal, init}};
+down(EventType, EventContent, StateData) ->
+  handle_common(EventType, EventContent, ?FUNCTION_NAME, StateData, postpone).
 
--spec terminate( Reason :: (normal | shutdown | {shutdown, term()} | term())
-               , State  :: state()
-               ) -> ok.
-terminate(_Reason, _State) ->
-  ok.
+-spec handle_common(_, _, _, _, _) -> _.
+handle_common({call, From}, gun_pid, _, #{gun_pid := GunPid}, _) ->
+  {keep_state_and_data, {reply, From, GunPid}};
+handle_common(cast, stop, _, _, _) ->
+  {stop, normal};
+handle_common( info
+             , {'DOWN', GunMon, process, GunPid, Reason}
+             , StateName
+             , #{gun_pid := GunPid, gun_monitor := GunMon} = StateData
+             , _) ->
+  {next_state, down, StateData,
+    {next_event, internal, {down, StateName, Reason}}};
+handle_common( state_timeout
+             , EventContent
+             , StateName
+             , #{gun_pid := GunPid} = StateData
+             , _) ->
+  gun:close(GunPid),
+  {next_state, down, StateData,
+    {next_event, internal, {state_timeout, StateName, EventContent}}};
+handle_common(_, _, _, _, postpone) ->
+  {keep_state_and_data, postpone};
+handle_common(_, _, _, _, drop) ->
+  keep_state_and_data.
 
 -spec code_change(OldVsn :: term() | {down, term()}
-                 , State
+                 , StateName
+                 , StateData
                  , Extra :: term()
-                 ) -> {ok, State}.
-code_change(_OldVsn, State, _Extra) ->
-  {ok, State}.
+                 ) -> {ok, StateName, StateData}.
+code_change(_OldVsn, StateName, StateData, _Extra) ->
+  {ok, StateName, StateData}.
 
 %%%===================================================================
 %%% Connection getters/setters Functions
@@ -317,16 +417,14 @@ keyfile(#{keyfile := Keyfile}) ->
 type(#{type := Type}) ->
   Type.
 
-%%%===================================================================
-%%% Internal Functions
-%%%===================================================================
+-spec proxy(connection()) -> proxy_info() | undefined.
+proxy(#{proxy_info := Proxy}) ->
+  Proxy;
+proxy(_) ->
+  undefined.
 
--spec open_gun_connection(connection()) -> GunConnectionPid :: pid().
-open_gun_connection(Connection) ->
-  Host = host(Connection),
-  Port = port(Connection),
-
-  TransportOpts = case type(Connection) of
+transport_opts(Connection) ->
+  case type(Connection) of
     certdata ->
       Cert = certdata(Connection),
       Key = keydata(Connection),
@@ -337,14 +435,11 @@ open_gun_connection(Connection) ->
       [{certfile, Certfile}, {keyfile, Keyfile}];
     token ->
       []
-  end,
+  end.
 
-  {ok, GunConnectionPid} = gun:open( Host
-                                   , Port
-                                   , #{ protocols => [http2]
-                                      , transport_opts => TransportOpts
-                                      }),
-  GunConnectionPid.
+%%%===================================================================
+%%% Internal Functions
+%%%===================================================================
 
 -spec get_headers(apns:headers()) -> list().
 get_headers(Headers) ->

--- a/test/connection_SUITE.erl
+++ b/test/connection_SUITE.erl
@@ -9,8 +9,10 @@
 -export([ default_connection/1
         , certdata_keydata_connection/1
         , connect/1
+        , connect_timeout/1
         , connect_without_name/1
-        , http2_connection_lost/1
+        , gun_connection_lost/1
+        , gun_connection_lost_timeout/1
         , push_notification/1
         , push_notification_token/1
         , push_notification_timeout/1
@@ -29,8 +31,10 @@
 all() ->  [ default_connection
           , certdata_keydata_connection
           , connect
+          , connect_timeout
           , connect_without_name
-          , http2_connection_lost
+          , gun_connection_lost
+          , gun_connection_lost_timeout
           , push_notification
           , push_notification_token
           , push_notification_timeout
@@ -99,7 +103,8 @@ certdata_keydata_connection(_Config) ->
 
 -spec connect(config()) -> ok.
 connect(_Config) ->
-  ok = mock_open_http2_connection(),
+  ok = mock_gun_open(),
+  ok = mock_gun_await_up({ok, http2}),
   ConnectionName = my_connection,
   {ok, ServerPid}  = apns:connect(cert, ConnectionName),
   true = is_process_alive(ServerPid),
@@ -108,9 +113,21 @@ connect(_Config) ->
   [_] = meck:unload(),
   ok.
 
+-spec connect_timeout(config()) -> ok.
+connect_timeout(_Config) ->
+  ok = mock_gun_open(),
+  ok = mock_gun_await_up({error, timeout}),
+  ConnectionName = my_connection,
+  {ok, Server} = apns:connect(token, ConnectionName),
+  {error, timeout} = apns:wait_for_connection_up(Server),
+  ok = close_connection(ConnectionName),
+  [_] = meck:unload(),
+  ok.
+
 -spec connect_without_name(config()) -> ok.
 connect_without_name(_Config) ->
-  ok = mock_open_http2_connection(),
+  ok = mock_gun_open(),
+  ok = mock_gun_await_up({ok, http2}),
   ConnectionName = undefined,
   {ok, ServerPid}  = apns:connect(cert, ConnectionName),
   true = is_process_alive(ServerPid),
@@ -118,51 +135,63 @@ connect_without_name(_Config) ->
   [_] = meck:unload(),
   ok.
 
--spec http2_connection_lost(config()) -> ok.
-http2_connection_lost(_Config) ->
-  ok = mock_open_http2_connection(),
-  ConnectionName = my_connection3,
+-spec gun_connection_lost(config()) -> ok.
+gun_connection_lost(_Config) ->
+  ok = mock_gun_open(),
+  ok = mock_gun_await_up({ok, http2}),
+  ConnectionName = my_connection2,
   {ok, ServerPid}  = apns:connect(cert, ConnectionName),
-
-  HTTP2Conn = apns_connection:http2_connection(ConnectionName),
-  HTTP2Conn = apns_connection:http2_connection(ServerPid),
-
-  true = is_process_alive(HTTP2Conn),
-  HTTP2Conn ! {crash, ServerPid},
-  ktn_task:wait_for(fun() -> is_process_alive(HTTP2Conn) end, false),
+  GunPid = apns_connection:gun_connection(ConnectionName),
+  true = is_process_alive(GunPid),
+  GunPid ! {crash, ServerPid},
+  ktn_task:wait_for(fun() -> is_process_alive(GunPid) end, false),
   ktn_task:wait_for(fun() ->
-      apns_connection:http2_connection(ConnectionName) == HTTP2Conn
+      apns_connection:gun_connection(ConnectionName) == GunPid
     end, false),
-  HTTP2Conn2 = apns_connection:http2_connection(ConnectionName),
-  true = is_process_alive(HTTP2Conn2),
-  true = (HTTP2Conn =/= HTTP2Conn2),
-
-  % Repeat with ceiling 0, for testing coverage
-  ok = application:set_env(apns, backoff_ceiling, 0),
-
-  ConnectionName2 = my_connection4,
-  {ok, ServerPid2}  = apns:connect(cert, ConnectionName2),
-  HTTP2Conn3 = apns_connection:http2_connection(ConnectionName2),
-  true = is_process_alive(HTTP2Conn3),
-
-  HTTP2Conn3 ! {crash, ServerPid2},
-  ktn_task:wait_for(fun() -> is_process_alive(HTTP2Conn3) end, false),
-  ktn_task:wait_for(fun() ->
-      apns_connection:http2_connection(ConnectionName2) == HTTP2Conn3
-    end, false),
-  HTTP2Conn4 = apns_connection:http2_connection(ConnectionName2),
-  true = is_process_alive(HTTP2Conn4),
-  true = (HTTP2Conn3 =/= HTTP2Conn4),
-
-  ok = application:unset_env(apns, backoff_ceiling),
+  GunPid2 = apns_connection:gun_connection(ConnectionName),
+  true = is_process_alive(GunPid2),
+  true = (GunPid =/= GunPid2),
   ok = close_connection(ConnectionName),
-  ktn_task:wait_for(fun() -> is_process_alive(HTTP2Conn2) end, false),
+  ktn_task:wait_for(fun() -> is_process_alive(GunPid2) end, false),
+  [_] = meck:unload(),
+  ok.
+
+-spec gun_connection_lost_timeout(config()) -> ok.
+gun_connection_lost_timeout(_Config) ->
+  ok = mock_gun_open(),
+  ok = mock_gun_await_up({ok, http2}),
+  ConnectionName = my_connection,
+  % when backoff is grater than ceiling
+  ok = application:set_env(apns, backoff_ceiling, 2),
+  {ok, _ServerPid}  = apns:connect(cert, ConnectionName),
+  GunPid = apns_connection:gun_connection(ConnectionName),
+
+  ok = mock_gun_await_up({error, timeout}),
+  ok = meck:expect(gun, close, fun(_) ->
+    ok
+  end),
+
+  ConnectionName ! reconnect,
+
+  ktn_task:wait_for(fun() ->
+      apns_connection:gun_connection(ConnectionName) == GunPid
+    end, false),
+
+  GunPid2 = apns_connection:gun_connection(ConnectionName),
+
+  ktn_task:wait_for(fun() ->
+      apns_connection:gun_connection(ConnectionName) == GunPid2
+    end, false),
+
+  ok = close_connection(ConnectionName),
+  ok = application:set_env(apns, backoff_ceiling, 10),
   [_] = meck:unload(),
   ok.
 
 -spec push_notification(config()) -> ok.
 push_notification(_Config) ->
-  ok = mock_open_http2_connection(),
+  ok = mock_gun_open(),
+  ok = mock_gun_await_up({ok, http2}),
   ConnectionName = my_connection,
   {ok, ServerPid} = apns:connect(cert, ConnectionName),
   Headers = #{ apns_id          => <<"apnsid">>
@@ -172,20 +201,21 @@ push_notification(_Config) ->
              },
   Notification = #{<<"aps">> => #{<<"alert">> => <<"you have a message">>}},
   DeviceId = <<"device_id">>,
-  ok = mock_http2_post(),
+  ok = mock_gun_post(),
   ResponseCode = 200,
   ResponseHeaders = [{<<"apns-id">>, <<"apnsid">>}],
-  ok = mock_http2_get_response(ResponseCode, ResponseHeaders, []),
-
+  ok = mock_gun_await({response, fin, ResponseCode, ResponseHeaders}),
   {ResponseCode, ResponseHeaders, no_body} =
     apns:push_notification(ConnectionName, DeviceId, Notification, Headers),
 
   %% Now mock an error from APNs
+  [_] = meck:unload(),
+  ok = mock_gun_post(),
   ErrorCode = 400,
   ErrorHeaders = [{<<"apns-id">>, <<"apnsid2">>}],
-  ErrorBody = [<<"{\"reason\":\"BadDeviceToken\"}">>],
-
-  ok = mock_http2_get_response(ErrorCode, ErrorHeaders, ErrorBody),
+  ErrorBody = <<"{\"reason\":\"BadTopic\"}">>,
+  ok = mock_gun_await({response, nofin, ErrorCode, ErrorHeaders}),
+  ok = mock_gun_await_body(ErrorBody),
 
   {ErrorCode, ErrorHeaders, ErrorBodyDecoded} =
     apns:push_notification(ConnectionName, DeviceId, Notification),
@@ -198,7 +228,8 @@ push_notification(_Config) ->
 
 -spec push_notification_token(config()) -> ok.
 push_notification_token(_Config) ->
-  ok = mock_open_http2_connection(),
+  ok = mock_gun_open(),
+  ok = mock_gun_await_up({ok, http2}),
   ConnectionName = my_token_connection,
   {ok, ServerPid} = apns:connect(token, ConnectionName),
   Headers = #{ apns_id          => <<"apnsid2">>
@@ -208,13 +239,14 @@ push_notification_token(_Config) ->
              },
   Notification = #{<<"aps">> => #{<<"alert">> => <<"more messages">>}},
   DeviceId = <<"device_id2">>,
-  ok = mock_http2_post(),
+
   ok = maybe_mock_apns_os(),
   Token = apns:generate_token(<<"TeamId">>, <<"KeyId">>),
 
+  ok = mock_gun_post(),
   ResponseCode = 200,
   ResponseHeaders = [{<<"apns-id">>, <<"apnsid2">>}],
-  ok = mock_http2_get_response(ResponseCode, ResponseHeaders, []),
+  ok = mock_gun_await({response, fin, ResponseCode, ResponseHeaders}),
   {ResponseCode, ResponseHeaders, no_body} =
     apns:push_notification_token( ConnectionName
                                 , Token
@@ -242,8 +274,9 @@ push_notification_token(_Config) ->
 
 -spec restrict_calls_to_owner(config()) -> ok.
 restrict_calls_to_owner(_Config) ->
-  ok = mock_open_http2_connection(),
-  ok = mock_http2_post(),
+  ok = mock_gun_open(),
+  ok = mock_gun_await_up({ok, http2}),
+  ok = mock_gun_post(),
   Self = self(),
 
   SpawnedPid = spawn(fun() ->
@@ -269,14 +302,14 @@ push_notification_timeout(_Config) ->
   {ok, OriginalTimeout} = application:get_env(apns, timeout),
   ok = application:set_env(apns, timeout, 0),
 
-  ok = mock_open_http2_connection(),
-  ok = mock_http2_post(),
-  ok = mock_http2_get_response(200, [{<<"apns-id">>, <<"apnsid">>}], []),
+  ok = mock_gun_open(),
+  ok = mock_gun_await_up({ok, http2}),
+  ok = mock_gun_post(),
   ConnectionName = my_connection,
   {ok, _ApnsPid} = apns:connect(cert, ConnectionName),
   Notification = #{<<"aps">> => #{<<"alert">> => <<"another message">>}},
   DeviceId = <<"device_id">>,
-  {timeout, _} = apns:push_notification(ConnectionName, DeviceId, Notification),
+  timeout = apns:push_notification(ConnectionName, DeviceId, Notification),
   ok = close_connection(ConnectionName),
   [_] = meck:unload(),
 
@@ -322,7 +355,8 @@ default_headers(_Config) ->
 
 -spec test_coverage(config()) -> ok.
 test_coverage(_Config) ->
-  ok = mock_open_http2_connection(),
+  ok = mock_gun_open(),
+  ok = mock_gun_await_up({ok, http2}),
   ConnectionName = my_connection,
   {ok, _ServerPid}  = apns:connect(cert, ConnectionName),
 
@@ -342,29 +376,40 @@ test_coverage(_Config) ->
 -spec test_function() -> ok.
 test_function() ->
   receive
-    normal       -> ok;
-    {crash, Pid} -> Pid ! {'EXIT', self(), no_reason};
-    _            -> test_function()
+    normal           -> ok;
+    {crash, Pid}     -> Pid ! {gun_down, self(), http2, closed, [], []};
+    _                -> test_function()
   end.
 
--spec mock_open_http2_connection() -> ok.
-mock_open_http2_connection() ->
-  meck:expect(h2_client, start_link, fun(https, _, _) ->
+-spec mock_gun_open() -> ok.
+mock_gun_open() ->
+  meck:expect(gun, open, fun(_, _, _) ->
     % Return a Pid but nothing special with it
     {ok, spawn(fun test_function/0)}
   end).
 
--spec mock_http2_post() -> ok.
-mock_http2_post() ->
-  meck:expect(h2_client, send_request, fun(_, _, _) ->
-    self() ! {'END_STREAM', 1},
-    {ok, 1}
+-spec mock_gun_post() -> ok.
+mock_gun_post() ->
+  meck:expect(gun, post, fun(_, _, _, _) ->
+    make_ref()
   end).
 
--spec mock_http2_get_response(integer(), list(), list()) -> ok.
-mock_http2_get_response(ResponseCode, ResponseHeaders, Body) ->
-  meck:expect(h2_client, get_response, fun(_, _) ->
-    {ok, {[{<<":status">>, integer_to_binary(ResponseCode)} | ResponseHeaders], Body}}
+-spec mock_gun_await(term()) -> ok.
+mock_gun_await(Result) ->
+  meck:expect(gun, await, fun(_, _, _) ->
+    Result
+  end).
+
+-spec mock_gun_await_body(term()) -> ok.
+mock_gun_await_body(Body) ->
+  meck:expect(gun, await_body, fun(_, _, _) ->
+    {ok, Body}
+  end).
+
+-spec mock_gun_await_up(term()) -> ok.
+mock_gun_await_up(Result) ->
+  meck:expect(gun, await_up, fun(_, _) ->
+    Result
   end).
 
 -spec maybe_mock_apns_os() -> ok.


### PR DESCRIPTION
Work in progress, it's missing a CONNECT test. Still would love if you could give a first quick review and see if I messed up anything.

While reverting to Gun I tried to keep some of the changes of the original switch, like returning before the connection is up. This works better in our case because we have pools of APNS connections and they're created at startup. But waiting for the connection_up can be useful so I moved it in a separate function instead of entirely removing it.

CONNECT requires Gun 1.2 which is not yet on hex. I am not pushing to hex myself yet, but I probably will before the end of the year once a couple barriers are taken down.