### PR TITLE
Pass on supported gun opts in connect()

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The other way is send all that info as a parameter to `apns:connect/1` function 
  , keyfile    => path()
  , timeout    => integer()
  , type       := type()
+ , gun        => gun:opts()
  }.
 ```
 
@@ -136,6 +137,13 @@ certfile => "priv/cert2.pem", keyfile => "priv/key2-noenc.pem", type => cert}).
 3> apns:connect(token, my_second_connection).
 {ok,<0.132.0>}
 ```
+
+## Passing options specific to Gun
+
+The actual connection is handled by the [gun](https://github.com/ninenines/gun) library,
+which supports some options of its own. You can pass options specific to `gun` in
+the `connection` struct using `gun => GunOpts`. See the `gun` documentation for
+examples.
 
 ## Push Notifications over `Provider Certificate` connections
 

--- a/elvis.config
+++ b/elvis.config
@@ -9,6 +9,7 @@
         rules => [
             {elvis_style, line_length, #{limit => 100}}
           , {elvis_style, god_modules, #{limit => 25, ignore => [apns_connection]}}
+          , {elvis_style, dont_repeat_yourself, #{min_complexity => 12}}
           ]
        },
       #{dirs => ["."],

--- a/src/apns_connection.erl
+++ b/src/apns_connection.erl
@@ -68,6 +68,7 @@
 -type path()         :: string().
 -type notification() :: binary().
 -type type()         :: certdata | cert | token.
+-type http_opts()    :: #{ keepalive => non_neg_integer() }.
 -type keydata()      :: {'RSAPrivateKey' | 'DSAPrivateKey' | 'ECPrivateKey' |
                          'PrivateKeyInfo'
                         , binary()}.
@@ -87,6 +88,7 @@
                          , timeout    => integer()
                          , type       := type()
                          , proxy_info => proxy_info()
+                         , http_opts  => http_opts()
                          }.
 
 -type state()        :: #{ connection      := connection()
@@ -227,25 +229,30 @@ open_origin(internal, _, #{connection := Connection} = StateData) ->
   Host = host(Connection),
   Port = port(Connection),
   TransportOpts = transport_opts(Connection),
+  Opts0 = #{ protocols      => [http2]
+           , transport_opts => TransportOpts
+           , retry          => 0
+           },
+  Opts = add_gun_opts(Connection, Opts0),
   {next_state, open_common, StateData,
     {next_event, internal, { Host
                            , Port
-                           , #{ protocols      => [http2]
-                              , transport_opts => TransportOpts
-                              , retry          => 0
-                              }}}}.
+                           , Opts}}}.
 
 -spec open_proxy(_, _, _) -> _.
 open_proxy(internal, _, StateData) ->
   #{connection := Connection} = StateData,
   #{type := connect, host := ProxyHost, port := ProxyPort} = proxy(Connection),
+  Opts0 = #{ protocols => [http]
+           , transport => tcp
+           , retry     => 0
+           },
+  Opts = add_gun_opts(Connection, Opts0),
   {next_state, open_common, StateData,
     {next_event, internal, { ProxyHost
                            , ProxyPort
-                           , #{ protocols => [http]
-                              , transport => tcp
-                              , retry     => 0
-                              }}}}.
+                           , Opts
+                           }}}.
 
 %% This function exists only to make Elvis happy.
 %% I do not think it makes things any easier to read.
@@ -492,3 +499,14 @@ backoff(N, Ceiling) ->
       NString = float_to_list(NextN, [{decimals, 0}]),
       list_to_integer(NString)
   end.
+
+add_gun_opts(Connection, Opts) ->
+    maps:merge(maps:with(gun_opts_keys(), Connection), Opts).
+
+gun_opts_keys() ->
+    [ connect_timeout
+    , http_opts
+    , http2_opts
+    , retry_timeout
+    , trace
+    , transport ].

--- a/src/apns_connection.erl
+++ b/src/apns_connection.erl
@@ -89,6 +89,7 @@
                          , type       := type()
                          , proxy_info => proxy_info()
                          , http_opts  => http_opts()
+                         , gun        => gun:opts()
                          }.
 
 -type state()        :: #{ connection      := connection()
@@ -501,12 +502,5 @@ backoff(N, Ceiling) ->
   end.
 
 add_gun_opts(Connection, Opts) ->
-    maps:merge(maps:with(gun_opts_keys(), Connection), Opts).
-
-gun_opts_keys() ->
-    [ connect_timeout
-    , http_opts
-    , http2_opts
-    , retry_timeout
-    , trace
-    , transport ].
+  GunOpts = maps:get(gun, Connection, #{}),
+  maps:merge(GunOpts, Opts).

--- a/test/connection_SUITE.erl
+++ b/test/connection_SUITE.erl
@@ -138,7 +138,7 @@ connect_with_gun_param(K, V) ->
   ConnectionName = ?FUNCTION_NAME,
   Connection = apns_connection:default_connection(cert, ConnectionName),
   ok = mock_gun_open_param(K),
-  {ok, ServerPid} = apns:connect(Connection#{K => V}),
+  {ok, ServerPid} = apns:connect(Connection#{gun => #{K => V}}),
   true = is_process_alive(ServerPid),
   ok = close_connection(ServerPid),
   [_] = meck:unload(),


### PR DESCRIPTION
This change allows users to pass on options supported by `gun` in a `connect()` call.

For example, this means that you can use alternative TLS port 2197 without `gun` guessing that you want TCP transport (add `transport => tls`), and you can set a longer `keepalive` than the default 5 seconds.