### PR TITLE
Import code coverage plugins as project plugins

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -67,7 +67,7 @@
 
 %% == Cover ==
 
-{plugins, [coveralls, {rebar3_codecov, "0.1.0"}]}.
+{project_plugins, [coveralls, {rebar3_codecov, "0.1.0"}]}.
 
 {cover_enabled, true}.
 


### PR DESCRIPTION
By importing the plugins as project plugins we don't impose them to the
consumer that depends on this project.