### PR TITLE
These changes were done to make apns4erl (v2) work with gun-2.0.0-rc.1.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,7 @@
 %% == Dependencies ==
 
 {deps, [
-  {gun, "1.3.3"},
+  {gun, "2.0.0-rc.1"},
   {jsx, "3.0.0"},
   {base64url, "1.0.1"}
 ]}.

--- a/src/apns_connection.erl
+++ b/src/apns_connection.erl
@@ -231,7 +231,9 @@ open_origin(internal, _, #{connection := Connection} = StateData) ->
     {next_event, internal, { Host
                            , Port
                            , #{ protocols      => [http2]
-                              , transport_opts => TransportOpts
+                              , tls_opts => TransportOpts
+                              , http_opts => #{keepalive => 5000}
+                              , http2_opts => #{keepalive => 5000}
                               , retry          => 0
                               }}}}.
 
@@ -244,6 +246,8 @@ open_proxy(internal, _, StateData) ->
                            , ProxyPort
                            , #{ protocols => [http]
                               , transport => tcp
+                              , http_opts => #{keepalive => infinity}
+                              , http2_opts => #{keepalive => infinity}
                               , retry     => 0
                               }}}}.
 


### PR DESCRIPTION
For details, please refer to:

https://github.com/inaka/apns4erl/issues/242
https://github.com/inaka/apns4erl/issues/245
https://github.com/ninenines/gun/issues/261
https://github.com/ninenines/gun/issues/263